### PR TITLE
Adjust makefile to do full clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ tidy:
 	$(RM) $(MANUSCRIPT)
 	$(RM) README
 	$(RM) -r $(DIRS)
-	$(RM) results/
+	$(RM) -r results/
 	$(RM) docs/RMD/*html
 	$(RM) docs/manuscript/*{tex,pdf}
 

--- a/Makefile
+++ b/Makefile
@@ -82,14 +82,14 @@ doc/manuscript/%.pdf : doc/manuscript/%.Rmd $(COMPONENTS) $(ANALYSES)
 # ALL of the analyses (the cache still exists)
 tidy:
 	$(RM) $(PARSE_DATA)
-	$(RM) data/*.{csv,rda,rdb} 
+	$(RM) data/*.{csv,rda,rdb,rds} 
 	$(RM) $(ANALYSES)
 	$(RM) $(MANUSCRIPT)
 	$(RM) README
 	$(RM) -r $(DIRS)
 	$(RM) -r results/
-	$(RM) docs/RMD/*html
-	$(RM) docs/manuscript/*{tex,pdf}
+	$(RM) doc/RMD/*html
+	$(RM) doc/manuscript/*{tex,pdf}
 
 .PHONY : clean
 

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ all: $(DIRS) README.md $(ANALYSES) $(MANUSCRIPT)
 # Bootstrap the  data by installing the dependencies
 # This is a specific target for the convenience of typing make bootstrap
 .PHONY: bootstrap
-bootstrap: results/bootstrap.txt
+bootstrap: $(DIRS) results/bootstrap.txt
 
 # Create the shared data set
 $(THE_DATA) : bootstrap $(PARSE_DATA)
@@ -82,10 +82,14 @@ doc/manuscript/%.pdf : doc/manuscript/%.Rmd $(COMPONENTS) $(ANALYSES)
 # ALL of the analyses (the cache still exists)
 tidy:
 	$(RM) $(PARSE_DATA)
+	$(RM) data/*.{csv,rda,rdb} 
 	$(RM) $(ANALYSES)
 	$(RM) $(MANUSCRIPT)
 	$(RM) README
 	$(RM) -r $(DIRS)
+	$(RM) results/
+	$(RM) docs/RMD/*html
+	$(RM) docs/manuscript/*{tex,pdf}
 
 .PHONY : clean
 


### PR DESCRIPTION
This removes all derived files when `make clean` is run. Previously, there were still data files and manuscript files available. This further enforces reproducibility.


```
$ make clean
rm -f results/data-comparison.md
rm -f data/*.{csv,rda,rdb,rds}
rm -f results/table-1.md results/MCG-virulence.md results/locus-stats.md results/MLG-distribution.md results/mlg-mcg.md results/RDA-analysis.md results/pop-diff.md results/tree.md results/wmn-differentiation.md results/by-year.md results/compare-aldrich-wolfe.md
rm -f doc/manuscript/manuscript.pdf doc/manuscript/manuscript_shell.tex
rm -f README
rm -f -r results/figures/publication results/tables/
rm -f -r results/
rm -f doc/RMD/*html
rm -f doc/manuscript/*{tex,pdf}
rm -f cache/*
$ tree -a --charset ascii -I .git
.
|-- .Rbuildignore
|-- .Rprofile
|-- .circleci
|   `-- config.yml
|-- .dockerignore
|-- .gitignore
|-- DESCRIPTION
|-- Dockerfile
|-- LICENSE
|-- Makefile
|-- README.Rmd
|-- README.md
|-- data
|   `-- raw
|       |-- 2017-02-16_binned-genotypes-genalex_SA.csv
|       `-- 2017-02-16_copy-of-binned-genotypes_SE.xlsx
|-- doc
|   |-- RMD
|   |   |-- MCG-virulence.Rmd
|   |   |-- MLG-distribution.Rmd
|   |   |-- RDA-analysis.Rmd
|   |   |-- by-year.Rmd
|   |   |-- compare-aldrich-wolfe.Rmd
|   |   |-- data-comparison.Rmd
|   |   |-- locus-stats.Rmd
|   |   |-- mlg-mcg.Rmd
|   |   |-- pop-diff.Rmd
|   |   |-- table-1.Rmd
|   |   |-- tree.Rmd
|   |   `-- wmn-differentiation.Rmd
|   `-- manuscript
|       |-- README.md
|       |-- abstract.md
|       |-- apa.csl
|       |-- images
|       |   |-- mcg-trimmed.png
|       |   `-- mcg.jpg
|       |-- manuscript.Rmd
|       |-- ssc_bibliography.bib
|       `-- wlpeerj.cls
|-- move-supplementary.sh
|-- tests.sh
`-- znk_analysis.Rproj

7 directories, 36 files
```